### PR TITLE
Fix quickstart.md when running process_hotpotqa.py script

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -29,7 +29,8 @@ wget https://huggingface.co/datasets/BeIR/hotpotqa/resolve/main/corpus.jsonl.gz 
 gunzip -c data/corpus/hotpotqa/corpus.jsonl.gz > data/corpus/hotpotqa/hpqa_corpus.jsonl
 
 # Process the corpus and build the search index
-python scripts/hotpotqa_search/process_hotpotqa.py
+cd scripts/hotpotqa_search
+python process_hotpotqa.py
 ```
 
 This script will:


### PR DESCRIPTION
Since process_hotpotqa.py uses relative paths like "../../data/corpus", we need to change directory before running it.