### PR TITLE
Fix execute method in search tool

### DIFF
--- a/agent_r1/tool/tools/search_tool.py
+++ b/agent_r1/tool/tools/search_tool.py
@@ -77,7 +77,11 @@ class SearchTool(Tool):
         Returns:
             Formatted search results
         """
-        pass
+        query = args["query"]
+        embedding = self.model.encode_queries([query])
+        dist, ids = self.index.search(embedding, 5)  # ids: 1*5
+        results_str = self._format_results(ids[0])
+        return results_str
     
     def batch_execute(self, args_list: List[Dict]) -> List[str]:
         queries = [x["query"] for x in args_list]

--- a/scripts/model_merge.sh
+++ b/scripts/model_merge.sh
@@ -1,3 +1,3 @@
 export CHECKPOINT_DIR=<your_checkpoint_dir>
 
-python3 verl/scripts/model_merger --local_dir $CHECKPOINT_DIR
+python3 verl/scripts/model_merger.py --local_dir $CHECKPOINT_DIR


### PR DESCRIPTION
This PR implements the execute method in search tool, so that in later run_chat.sh or run_infer.sh, we can actually see tool results. Otherwise it will always be `None`