### PR TITLE
Fix DP dispatch padding gradient bias in FSDP training

### DIFF
--- a/agent_r1/trainer/main_agent_ppo.py
+++ b/agent_r1/trainer/main_agent_ppo.py
@@ -123,7 +123,7 @@ class TaskRunner:
 
         # use new model engine implementation
         if use_legacy_worker_impl == "disable":
-            from verl.workers.engine_workers import ActorRolloutRefWorker
+            from agent_r1.workers.engine_workers import ActorRolloutRefWorker
 
             actor_rollout_cls = ActorRolloutRefWorker
             ray_worker_group_cls = RayWorkerGroup
@@ -140,7 +140,7 @@ class TaskRunner:
         # Note: sync mode validation is now handled in RolloutConfig.__post_init__
         # Always use async worker since sync mode is deprecated and rejected
         if config.actor_rollout_ref.actor.strategy in {"fsdp", "fsdp2"}:
-            from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker
+            from agent_r1.workers.fsdp_workers import AsyncActorRolloutRefWorker
 
             actor_rollout_cls = AsyncActorRolloutRefWorker
             ray_worker_group_cls = RayWorkerGroup
@@ -163,10 +163,10 @@ class TaskRunner:
         use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
         if config.critic.strategy in {"fsdp", "fsdp2"}:
             if use_legacy_worker_impl in ["auto", "enable"]:
-                from verl.workers.fsdp_workers import CriticWorker
+                from agent_r1.workers.fsdp_workers import CriticWorker
             elif use_legacy_worker_impl == "disable":
                 # we don't need to specialize critic worker. Just use TrainingWorker
-                from verl.workers.engine_workers import TrainingWorker
+                from agent_r1.workers.engine_workers import TrainingWorker
 
                 CriticWorker = TrainingWorker
                 print("Using new worker implementation")

--- a/agent_r1/trainer/ppo/core_algos.py
+++ b/agent_r1/trainer/ppo/core_algos.py
@@ -19,6 +19,7 @@ implement PPO-like algorithms.
 """
 
 from collections import defaultdict
+from typing import Any, Optional
 
 import numpy as np
 import torch
@@ -315,3 +316,248 @@ def compute_grpo_outcome_advantage(
         scores = scores.unsqueeze(-1) * response_mask
 
     return scores, scores
+
+
+def agg_loss(
+    loss_mat: torch.Tensor,
+    loss_mask: torch.Tensor,
+    loss_agg_mode: str,
+    dp_size: int = 1,
+    batch_num_tokens: Optional[int] = None,
+    global_batch_size: Optional[int] = None,
+    loss_scale_factor: Optional[int] = None,
+):
+    """Aggregate loss with pad-aware sequence counting and zero-safe empty-batch handling."""
+    if loss_agg_mode == "token-mean":
+        if batch_num_tokens is None:
+            denom = loss_mask.sum()
+        else:
+            denom = batch_num_tokens
+        if denom.detach().item() == 0:
+            return loss_mat.sum() * 0.0
+        loss = verl_F.masked_sum(loss_mat, loss_mask) / denom * dp_size
+    elif loss_agg_mode == "seq-mean-token-sum":
+        seq_losses = torch.sum(loss_mat * loss_mask, dim=-1)
+        seq_mask = (torch.sum(loss_mask, dim=-1) > 0).float()
+        if global_batch_size is None:
+            denom = seq_mask.sum()
+        else:
+            denom = global_batch_size
+        if denom.detach().item() == 0:
+            return loss_mat.sum() * 0.0
+        loss = verl_F.masked_sum(seq_losses, seq_mask) / denom * dp_size
+    elif loss_agg_mode == "seq-mean-token-mean":
+        seq_token_count = torch.sum(loss_mask, dim=-1)
+        seq_losses = torch.sum(loss_mat * loss_mask, dim=-1) / (seq_token_count + 1e-8)
+        seq_mask = (seq_token_count > 0).float()
+        if global_batch_size is None:
+            denom = seq_mask.sum()
+        else:
+            denom = global_batch_size
+        if denom.detach().item() == 0:
+            return loss_mat.sum() * 0.0
+        loss = verl_F.masked_sum(seq_losses, seq_mask) / denom * dp_size
+    elif loss_agg_mode == "seq-mean-token-sum-norm":
+        seq_losses = torch.sum(loss_mat * loss_mask, dim=-1)
+        if loss_scale_factor is None:
+            loss_scale_factor = loss_mask.shape[-1]
+        if loss_scale_factor == 0:
+            return loss_mat.sum() * 0.0
+        loss = torch.sum(seq_losses) / loss_scale_factor
+    else:
+        raise ValueError(f"Invalid loss_agg_mode: {loss_agg_mode}")
+
+    return loss
+
+
+def compute_value_loss(
+    vpreds: torch.Tensor,
+    returns: torch.Tensor,
+    values: torch.Tensor,
+    response_mask: torch.Tensor,
+    cliprange_value: float,
+    loss_agg_mode: str = "token-mean",
+):
+    """Local value loss that uses pad-aware `agg_loss`."""
+    vpredclipped = verl_F.clip_by_value(vpreds, values - cliprange_value, values + cliprange_value)
+    vf_losses1 = (vpreds - returns) ** 2
+    vf_losses2 = (vpredclipped - returns) ** 2
+    clipped_vf_losses = torch.max(vf_losses1, vf_losses2)
+    vf_loss = 0.5 * agg_loss(loss_mat=clipped_vf_losses, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+    vf_clipfrac = verl_F.masked_mean(torch.gt(vf_losses2, vf_losses1).float(), response_mask)
+    return vf_loss, vf_clipfrac
+
+
+def compute_policy_loss_vanilla(
+    old_log_prob: torch.Tensor,
+    log_prob: torch.Tensor,
+    advantages: torch.Tensor,
+    response_mask: torch.Tensor,
+    loss_agg_mode: str = "token-mean",
+    config: Optional[Any] = None,
+    rollout_is_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    assert config is not None
+
+    clip_ratio = config.clip_ratio
+    clip_ratio_low = config.clip_ratio_low if config.clip_ratio_low is not None else clip_ratio
+    clip_ratio_high = config.clip_ratio_high if config.clip_ratio_high is not None else clip_ratio
+    clip_ratio_c = config.get("clip_ratio_c", 3.0)
+
+    assert clip_ratio_c > 1.0, (
+        "The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0,"
+        + f" but get the value: {clip_ratio_c}."
+    )
+
+    negative_approx_kl = log_prob - old_log_prob
+    negative_approx_kl = torch.clamp(negative_approx_kl, min=-20.0, max=20.0)
+    ratio = torch.exp(negative_approx_kl)
+    ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
+
+    pg_losses1 = -advantages * ratio
+    pg_losses2 = -advantages * torch.clamp(ratio, 1 - clip_ratio_low, 1 + clip_ratio_high)
+    clip_pg_losses1 = torch.maximum(pg_losses1, pg_losses2)
+    pg_clipfrac = verl_F.masked_mean(torch.gt(pg_losses2, pg_losses1).float(), response_mask)
+
+    pg_losses3 = -advantages * clip_ratio_c
+    clip_pg_losses2 = torch.min(pg_losses3, clip_pg_losses1)
+    pg_clipfrac_lower = verl_F.masked_mean(
+        torch.gt(clip_pg_losses1, pg_losses3) * (advantages < 0).float(), response_mask
+    )
+
+    pg_losses = torch.where(advantages < 0, clip_pg_losses2, clip_pg_losses1)
+    if rollout_is_weights is not None:
+        pg_losses = pg_losses * rollout_is_weights
+
+    pg_loss = agg_loss(
+        loss_mat=pg_losses,
+        loss_mask=response_mask,
+        loss_agg_mode=loss_agg_mode,
+        **getattr(config, "global_batch_info", {}),
+    )
+    pg_metrics = {
+        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
+        "actor/ppo_kl": ppo_kl.detach().item(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+    }
+    return pg_loss, pg_metrics
+
+
+def compute_policy_loss_reinforce(
+    rollout_log_prob: torch.Tensor,
+    log_prob: torch.Tensor,
+    advantages: torch.Tensor,
+    response_mask: torch.Tensor,
+    loss_agg_mode: str = "seq-mean-token-sum",
+    config: Optional[Any] = None,
+    rollout_is_weights: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    assert config is not None, "ActorConfig must be provided for REINFORCE loss"
+
+    if rollout_is_weights is not None:
+        pg_losses = -advantages * log_prob * rollout_is_weights
+    else:
+        pg_losses = -advantages * log_prob
+
+    pg_loss = agg_loss(
+        loss_mat=pg_losses,
+        loss_mask=response_mask,
+        loss_agg_mode=loss_agg_mode,
+        **getattr(config, "global_batch_info", {}),
+    )
+
+    negative_approx_kl = log_prob - rollout_log_prob
+    kl_divergence = verl_F.masked_mean(-negative_approx_kl, response_mask)
+
+    pg_metrics = {
+        "actor/ppo_kl": kl_divergence.detach().item(),
+    }
+    return pg_loss, pg_metrics
+
+
+def compute_policy_loss_bypass_mode(
+    old_log_prob: torch.Tensor,
+    log_prob: torch.Tensor,
+    advantages: torch.Tensor,
+    response_mask: torch.Tensor,
+    loss_agg_mode: str = "token-mean",
+    config: Optional[Any] = None,
+    rollout_is_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_rejection_mask
+
+    assert config is not None, "config is required for bypass_mode loss"
+    del rollout_is_weights
+
+    rollout_corr_config = config.policy_loss.get("rollout_correction", None) if hasattr(config, "policy_loss") else None
+    if rollout_corr_config is None:
+        raise ValueError(
+            "rollout_correction config not found in policy_loss. "
+            "When using loss_mode='bypass_mode', ensure rollout_correction config is passed."
+        )
+
+    loss_type = rollout_corr_config.get("loss_type", "ppo_clip")
+    rollout_is = rollout_corr_config.get("rollout_is", None)
+    rollout_is_threshold = rollout_corr_config.get("rollout_is_threshold", 2.0)
+    rollout_rs = rollout_corr_config.get("rollout_rs", None)
+    rollout_rs_threshold = rollout_corr_config.get("rollout_rs_threshold", None)
+    rollout_rs_threshold_lower = rollout_corr_config.get("rollout_rs_threshold_lower", None)
+    rollout_token_veto_threshold = rollout_corr_config.get("rollout_token_veto_threshold", None)
+    rollout_is_batch_normalize = rollout_corr_config.get("rollout_is_batch_normalize", True)
+
+    rollout_log_prob = old_log_prob
+    rollout_metrics, modified_response_mask, rollout_is_weights_proto = compute_rollout_correction_and_rejection_mask(
+        old_log_prob=log_prob,
+        rollout_log_prob=rollout_log_prob,
+        response_mask=response_mask,
+        rollout_is=rollout_is,
+        rollout_is_threshold=rollout_is_threshold,
+        rollout_rs=rollout_rs,
+        rollout_rs_threshold=rollout_rs_threshold,
+        rollout_rs_threshold_lower=rollout_rs_threshold_lower,
+        rollout_token_veto_threshold=rollout_token_veto_threshold,
+        rollout_is_batch_normalize=rollout_is_batch_normalize,
+    )
+
+    computed_is_weights = rollout_is_weights_proto.batch["rollout_is_weights"] if rollout_is_weights_proto else None
+    effective_mask = modified_response_mask
+
+    if loss_type == "reinforce":
+        pg_loss, pg_metrics = compute_policy_loss_reinforce(
+            rollout_log_prob=rollout_log_prob,
+            log_prob=log_prob,
+            advantages=advantages,
+            response_mask=effective_mask,
+            loss_agg_mode=loss_agg_mode,
+            config=config,
+            rollout_is_weights=computed_is_weights,
+        )
+    elif loss_type == "ppo_clip":
+        pg_loss, pg_metrics = compute_policy_loss_vanilla(
+            old_log_prob=rollout_log_prob,
+            log_prob=log_prob,
+            advantages=advantages,
+            response_mask=effective_mask,
+            loss_agg_mode=loss_agg_mode,
+            config=config,
+            rollout_is_weights=None,
+        )
+    else:
+        raise ValueError(f"Invalid loss_type: {loss_type}. Must be 'reinforce' or 'ppo_clip'.")
+
+    pg_metrics.update(rollout_metrics)
+    return pg_loss, pg_metrics
+
+
+def get_policy_loss_fn(name: str):
+    local_policy_loss_fns = {
+        "vanilla": compute_policy_loss_vanilla,
+        "reinforce": compute_policy_loss_reinforce,
+        "bypass_mode": compute_policy_loss_bypass_mode,
+    }
+    if name in local_policy_loss_fns:
+        return local_policy_loss_fns[name]
+
+    from verl.trainer.ppo.core_algos import get_policy_loss_fn as upstream_get_policy_loss_fn
+
+    return upstream_get_policy_loss_fn(name)

--- a/agent_r1/trainer/ppo/core_algos.py
+++ b/agent_r1/trainer/ppo/core_algos.py
@@ -328,12 +328,18 @@ def agg_loss(
     loss_scale_factor: Optional[int] = None,
 ):
     """Aggregate loss with pad-aware sequence counting and zero-safe empty-batch handling."""
+
+    def is_zero_denom(denom):
+        if torch.is_tensor(denom):
+            return denom.detach().item() == 0
+        return denom == 0
+
     if loss_agg_mode == "token-mean":
         if batch_num_tokens is None:
             denom = loss_mask.sum()
         else:
             denom = batch_num_tokens
-        if denom.detach().item() == 0:
+        if is_zero_denom(denom):
             return loss_mat.sum() * 0.0
         loss = verl_F.masked_sum(loss_mat, loss_mask) / denom * dp_size
     elif loss_agg_mode == "seq-mean-token-sum":
@@ -343,7 +349,7 @@ def agg_loss(
             denom = seq_mask.sum()
         else:
             denom = global_batch_size
-        if denom.detach().item() == 0:
+        if is_zero_denom(denom):
             return loss_mat.sum() * 0.0
         loss = verl_F.masked_sum(seq_losses, seq_mask) / denom * dp_size
     elif loss_agg_mode == "seq-mean-token-mean":
@@ -354,7 +360,7 @@ def agg_loss(
             denom = seq_mask.sum()
         else:
             denom = global_batch_size
-        if denom.detach().item() == 0:
+        if is_zero_denom(denom):
             return loss_mat.sum() * 0.0
         loss = verl_F.masked_sum(seq_losses, seq_mask) / denom * dp_size
     elif loss_agg_mode == "seq-mean-token-sum-norm":

--- a/agent_r1/trainer/ppo/ray_trainer.py
+++ b/agent_r1/trainer/ppo/ray_trainer.py
@@ -97,15 +97,11 @@ def assign_global_mini_batch_ids(batch: DataProto, mini_batch_size: int, dp_size
     local_mini_batch_size = mini_batch_size // dp_size
     if local_mini_batch_size == 0:
         raise ValueError(f"local_mini_batch_size must be positive, got {local_mini_batch_size}")
-    if local_batch_size % local_mini_batch_size != 0:
-        raise ValueError(
-            f"local_batch_size ({local_batch_size}) must be divisible by "
-            f"local_mini_batch_size ({local_mini_batch_size})"
-        )
 
-    num_mini_batches = local_batch_size // local_mini_batch_size
+    num_mini_batches = math.ceil(local_batch_size / local_mini_batch_size)
     device = batch.batch["prompts"].device
     local_ids = torch.arange(num_mini_batches, dtype=torch.long, device=device).repeat_interleave(local_mini_batch_size)
+    local_ids = local_ids[:local_batch_size]
     mini_batch_ids = local_ids.repeat(dp_size)
     batch.batch["mini_batch_id"] = mini_batch_ids
 
@@ -119,11 +115,11 @@ def assign_global_mini_batch_ids(batch: DataProto, mini_batch_size: int, dp_size
     batch.batch["mini_batch_global_size"] = mini_batch_sizes[mini_batch_ids]
 
     token_counts = batch.batch["attention_mask"].sum(dim=-1).to(dtype=torch.long)
-    mini_batch_token_nums = torch.empty((batch_size, mini_batch_size), dtype=torch.long, device=device)
+    mini_batch_token_nums = torch.zeros((batch_size, mini_batch_size), dtype=torch.long, device=device)
     for mini_batch_id in range(num_mini_batches):
         indices = torch.nonzero(mini_batch_ids == mini_batch_id, as_tuple=False).flatten()
         token_nums = token_counts[indices]
-        mini_batch_token_nums[indices] = token_nums.unsqueeze(0).expand(indices.numel(), -1)
+        mini_batch_token_nums[indices, : token_nums.numel()] = token_nums.unsqueeze(0).expand(indices.numel(), -1)
     batch.batch["mini_batch_global_token_num"] = mini_batch_token_nums
 
 

--- a/agent_r1/trainer/ppo/ray_trainer.py
+++ b/agent_r1/trainer/ppo/ray_trainer.py
@@ -71,14 +71,60 @@ def get_valid_data(data: DataProto) -> tuple[DataProto, torch.Tensor]:
         tuple[DataProto, torch.Tensor]: A tuple containing the valid data and a boolean mask
             of valid indices.
     """
-    is_pad = data.non_tensor_batch.get("is_pad", None)
-    if is_pad is not None:
-        valid_mask = torch.from_numpy(~is_pad).to(data.batch.device)
+    sample_mask = data.batch.get("sample_mask", None)
+    if sample_mask is not None:
+        valid_mask = sample_mask.to(dtype=torch.bool)
         valid_data = data.select_idxs(valid_mask)
-    else:
-        valid_mask = torch.ones(len(data), dtype=torch.bool, device=data.batch.device)
-        valid_data = data
+        return valid_data, valid_mask
+
+    valid_mask = torch.ones(len(data), dtype=torch.bool, device=data.batch.device)
+    valid_data = data
     return valid_data, valid_mask
+
+
+def assign_global_mini_batch_ids(batch: DataProto, mini_batch_size: int, dp_size: int) -> None:
+    """Assign global PPO mini-batch ids while preserving the existing DP dispatch layout."""
+    if dp_size <= 0:
+        raise ValueError(f"dp_size must be positive, got {dp_size}")
+    if mini_batch_size % dp_size != 0:
+        raise ValueError(f"mini_batch_size ({mini_batch_size}) must be divisible by dp_size ({dp_size})")
+
+    batch_size = len(batch)
+    if batch_size % dp_size != 0:
+        raise ValueError(f"batch_size ({batch_size}) must be divisible by dp_size ({dp_size})")
+
+    local_batch_size = batch_size // dp_size
+    local_mini_batch_size = mini_batch_size // dp_size
+    if local_mini_batch_size == 0:
+        raise ValueError(f"local_mini_batch_size must be positive, got {local_mini_batch_size}")
+    if local_batch_size % local_mini_batch_size != 0:
+        raise ValueError(
+            f"local_batch_size ({local_batch_size}) must be divisible by "
+            f"local_mini_batch_size ({local_mini_batch_size})"
+        )
+
+    num_mini_batches = local_batch_size // local_mini_batch_size
+    device = batch.batch["prompts"].device
+    local_ids = torch.arange(num_mini_batches, dtype=torch.long, device=device).repeat_interleave(local_mini_batch_size)
+    mini_batch_ids = local_ids.repeat(dp_size)
+    batch.batch["mini_batch_id"] = mini_batch_ids
+
+    response_mask = batch.batch.get("response_mask", None)
+    if response_mask is None:
+        seq_mask = torch.ones(batch_size, dtype=torch.long, device=device)
+    else:
+        seq_mask = response_mask.any(dim=-1).to(dtype=torch.long)
+    mini_batch_sizes = torch.zeros(num_mini_batches, dtype=torch.long, device=device)
+    mini_batch_sizes.scatter_add_(0, mini_batch_ids, seq_mask)
+    batch.batch["mini_batch_global_size"] = mini_batch_sizes[mini_batch_ids]
+
+    token_counts = batch.batch["attention_mask"].sum(dim=-1).to(dtype=torch.long)
+    mini_batch_token_nums = torch.empty((batch_size, mini_batch_size), dtype=torch.long, device=device)
+    for mini_batch_id in range(num_mini_batches):
+        indices = torch.nonzero(mini_batch_ids == mini_batch_id, as_tuple=False).flatten()
+        token_nums = token_counts[indices]
+        mini_batch_token_nums[indices] = token_nums.unsqueeze(0).expand(indices.numel(), -1)
+    batch.batch["mini_batch_global_token_num"] = mini_batch_token_nums
 
 
 def make_json_safe(value):
@@ -239,6 +285,85 @@ class RayAgentTrainer(RayPPOTrainer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.use_reward_loop = True
+
+    def _update_actor(self, batch: DataProto) -> DataProto:
+        rollout_config = self.config.actor_rollout_ref.rollout
+        batch.meta_info["multi_turn"] = rollout_config.multi_turn.enable
+        batch.meta_info["temperature"] = rollout_config.temperature
+        if self.use_legacy_worker_impl == "disable":
+            from verl.utils import tensordict_utils as tu
+            from verl.utils.py_functional import rename_dict
+            from verl.workers.utils.padding import left_right_2_no_padding
+
+            calculate_entropy = self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
+            ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
+            ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+            dp_size = self._get_dp_size(self.actor_rollout_wg, "actor")
+            assign_global_mini_batch_ids(batch, mini_batch_size=ppo_mini_batch_size, dp_size=dp_size)
+            batch_td = batch.to_tensordict()
+            batch_td = left_right_2_no_padding(batch_td)
+            ppo_epochs = self.config.actor_rollout_ref.actor.ppo_epochs
+            seed = self.config.actor_rollout_ref.actor.data_loader_seed
+            shuffle = self.config.actor_rollout_ref.actor.shuffle
+            tu.assign_non_tensor(
+                batch_td,
+                calculate_entropy=calculate_entropy,
+                mini_batch_size=ppo_mini_batch_size,
+                epochs=ppo_epochs,
+                seed=seed,
+                dataloader_kwargs={"shuffle": shuffle},
+            )
+
+            actor_output = self.actor_rollout_wg.update_actor(batch_td)
+            actor_output = tu.get(actor_output, "metrics")
+            actor_output = rename_dict(actor_output, "actor/")
+            actor_output["perf/mfu/actor"] = actor_output.pop("actor/mfu")
+            actor_output = DataProto.from_single_dict(data={}, meta_info={"metrics": actor_output})
+        else:
+            actor_output = self.actor_rollout_wg.update_actor(batch)
+        return actor_output
+
+    def _update_critic(self, batch: DataProto) -> DataProto:
+        if self.use_legacy_worker_impl == "disable":
+            from verl.utils import tensordict_utils as tu
+            from verl.utils.py_functional import rename_dict
+            from verl.workers.utils.padding import left_right_2_no_padding
+
+            ppo_mini_batch_size = self.config.critic.ppo_mini_batch_size
+            ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+            dp_size = self._get_worker_group_dp_size(self.critic_wg, ("train", "critic"))
+            assign_global_mini_batch_ids(batch, mini_batch_size=ppo_mini_batch_size, dp_size=dp_size)
+            batch_td = batch.to_tensordict()
+            batch_td = left_right_2_no_padding(batch_td)
+            ppo_epochs = self.config.critic.ppo_epochs
+            seed = self.config.critic.data_loader_seed
+            shuffle = self.config.critic.shuffle
+            tu.assign_non_tensor(
+                batch_td,
+                mini_batch_size=ppo_mini_batch_size,
+                epochs=ppo_epochs,
+                seed=seed,
+                dataloader_kwargs={"shuffle": shuffle},
+            )
+
+            output = self.critic_wg.train_mini_batch(batch_td)
+            output = output.get()
+            output = tu.get(output, "metrics")
+            output = rename_dict(output, "critic/")
+            output["perf/mfu/critic"] = output.pop("critic/mfu")
+            output = DataProto.from_single_dict(data={}, meta_info={"metrics": output})
+        else:
+            output = self.critic_wg.update_critic(batch)
+        return output
+
+    def _get_worker_group_dp_size(self, worker_group, roles: Sequence[str]) -> int:
+        """Return DP size for the first registered mesh role, falling back to world size."""
+        for role in roles:
+            try:
+                return self._get_dp_size(worker_group, role)
+            except (AssertionError, KeyError, ValueError):
+                continue
+        return worker_group.world_size
 
     def _dump_generations(
         self,
@@ -607,7 +732,7 @@ class RayAgentTrainer(RayPPOTrainer):
                 # assign critic loss
                 from functools import partial
 
-                from verl.workers.utils.losses import value_loss
+                from agent_r1.workers.utils.losses import value_loss
 
                 value_loss_ = partial(value_loss, config=orig_critic_cfg)
                 self.critic_wg.set_loss_fn(value_loss_)
@@ -898,6 +1023,9 @@ class RayAgentTrainer(RayPPOTrainer):
                             # so index 0 corresponds to the prompt-last position (before response[0]).
                             value_mask = torch.zeros_like(response_mask)
                             value_mask[:, 0] = 1
+                            sample_mask = batch.batch.get("sample_mask", None)
+                            if sample_mask is not None:
+                                value_mask[~sample_mask.to(dtype=torch.bool)] = 0
                             batch.batch["response_mask"] = value_mask
 
                             # update critic
@@ -1019,26 +1147,33 @@ class RayAgentTrainer(RayPPOTrainer):
                     self.train_dataset.on_batch_end(batch=batch)
 
     def _pad_dataproto_to_world_size(self, batch):
-        world_sizes = []
+        dp_sizes = []
         if self.use_critic and self.critic_wg.world_size != 0:
-            world_sizes.append(self.critic_wg.world_size)
+            critic_roles = ("train", "critic") if self.use_legacy_worker_impl == "disable" else ("critic",)
+            dp_sizes.append(self._get_worker_group_dp_size(self.critic_wg, critic_roles))
         if self.use_reference_policy and self.ref_policy_wg.world_size != 0:
-            world_sizes.append(self.ref_policy_wg.world_size)
+            ref_roles = ("ref", "actor") if self.use_legacy_worker_impl == "disable" else ("actor", "ref")
+            dp_sizes.append(self._get_worker_group_dp_size(self.ref_policy_wg, ref_roles))
         if self.hybrid_engine:
             if self.actor_rollout_wg.world_size != 0:
-                world_sizes.append(self.actor_rollout_wg.world_size)
+                dp_sizes.append(self._get_worker_group_dp_size(self.actor_rollout_wg, ("actor",)))
         else:
             if self.actor_wg.world_size != 0:
-                world_sizes.append(self.actor_wg.world_size)
-            if self.rollout_wg.world_size != 0:
-                world_sizes.append(self.rollout_wg.world_size)
-        if not world_sizes:
+                dp_sizes.append(self._get_worker_group_dp_size(self.actor_wg, ("actor",)))
+        if not dp_sizes:
             return batch
 
-        world_size = reduce(math.lcm, world_sizes)
+        # Rollout already finished before this point; only pad for post-rollout training consumers.
+        size_divisor = reduce(math.lcm, dp_sizes)
 
         original_batch_size = batch.batch["prompts"].shape[0]
-        batch, pad_size = pad_dataproto_to_divisor(batch, world_size)
-        batch.non_tensor_batch["is_pad"] = np.array([False] * original_batch_size + [True] * pad_size)
+        batch, pad_size = pad_dataproto_to_divisor(batch, size_divisor)
+        sample_mask = torch.ones(len(batch), dtype=torch.bool, device=batch.batch["prompts"].device)
+        if pad_size > 0:
+            sample_mask[original_batch_size:] = False
+        batch.batch["sample_mask"] = sample_mask
+
+        if "response_mask" in batch.batch:
+            batch.batch["response_mask"][~sample_mask] = 0
 
         return batch

--- a/agent_r1/trainer/ppo/ray_trainer.py
+++ b/agent_r1/trainer/ppo/ray_trainer.py
@@ -981,7 +981,6 @@ class RayAgentTrainer(RayPPOTrainer):
                         # Compute rollout correction: IS weights, rejection sampling, and metrics
                         # Only runs in decoupled mode (computes once per batch using stable π_old)
                         # In bypass mode, this is skipped - actor computes metrics from evolving π_θ vs π_rollout
-                        # TODO: is_metrics 修正，如何过滤掉 pad 的 step？
                         if (
                             rollout_corr_config is not None
                             and "rollout_log_probs" in batch.batch

--- a/agent_r1/workers/__init__.py
+++ b/agent_r1/workers/__init__.py
@@ -1,0 +1,1 @@
+"""Agent-R1 local worker overrides."""

--- a/agent_r1/workers/actor/__init__.py
+++ b/agent_r1/workers/actor/__init__.py
@@ -1,0 +1,3 @@
+from .dp_actor import DataParallelPPOActor
+
+__all__ = ["DataParallelPPOActor"]

--- a/agent_r1/workers/actor/dp_actor.py
+++ b/agent_r1/workers/actor/dp_actor.py
@@ -1,0 +1,166 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Agent-R1 local PPO actor overrides.
+"""
+
+import logging
+import os
+
+from agent_r1.trainer.ppo.core_algos import agg_loss, get_policy_loss_fn
+from verl import DataProto
+from verl.trainer.ppo.core_algos import kl_penalty
+from verl.utils.device import get_device_id
+from verl.utils.profiler import GPUMemoryLogger
+from verl.utils.py_functional import append_to_dict
+from verl.utils.seqlen_balancing import prepare_dynamic_batch
+from verl.workers.actor.dp_actor import DataParallelPPOActor as VerlDataParallelPPOActor
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class DataParallelPPOActor(VerlDataParallelPPOActor):
+    @GPUMemoryLogger(role="dp actor", logger=logger)
+    def update_policy(self, data: DataProto):
+        self.actor_module.train()
+
+        temperature = data.meta_info["temperature"]
+
+        select_keys = [
+            "responses",
+            "response_mask",
+            "input_ids",
+            "attention_mask",
+            "position_ids",
+            "old_log_probs",
+            "advantages",
+        ]
+        if self.config.use_kl_loss:
+            select_keys.append("ref_log_prob")
+        if "rollout_is_weights" in data.batch.keys():
+            select_keys.append("rollout_is_weights")
+        if "rollout_log_probs" in data.batch.keys():
+            select_keys.append("rollout_log_probs")
+
+        has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
+        non_tensor_select_keys = ["multi_modal_inputs"] if has_multi_modal_inputs else []
+
+        data = data.select(batch_keys=select_keys, non_tensor_batch_keys=non_tensor_select_keys)
+        mini_batches = data.split(self.config.ppo_mini_batch_size)
+        on_policy = len(mini_batches) == 1 and self.config.ppo_epochs == 1
+
+        metrics = {
+            "actor/pg_loss": 0.0,
+            "actor/kl_loss": 0.0,
+        }
+        for _ in range(self.config.ppo_epochs):
+            for mini_batch in mini_batches:
+                if self.config.use_dynamic_bsz:
+                    max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
+                    micro_batches, _ = prepare_dynamic_batch(mini_batch, max_token_len=max_token_len)
+                else:
+                    micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)
+
+                micro_batches = [mb for mb in micro_batches if bool(mb.batch["response_mask"].any().item())]
+                if not micro_batches:
+                    append_to_dict(metrics, {"actor/grad_norm": 0.0})
+                    continue
+
+                if not self.config.use_dynamic_bsz:
+                    self.gradient_accumulation = len(micro_batches)
+
+                self.actor_optimizer.zero_grad()
+
+                for micro_batch in micro_batches:
+                    micro_batch = micro_batch.to(get_device_id())
+                    micro_batch_metrics = {}
+                    model_inputs = {**micro_batch.batch, **micro_batch.non_tensor_batch}
+                    response_mask = model_inputs["response_mask"]
+                    advantages = model_inputs["advantages"]
+
+                    entropy_coeff = self.config.entropy_coeff
+                    loss_agg_mode = self.config.loss_agg_mode
+                    calculate_entropy = self.config.calculate_entropy or (entropy_coeff != 0)
+
+                    if self.config.use_dynamic_bsz:
+                        loss_scale_factor = response_mask.shape[0] / self.config.ppo_mini_batch_size
+                    else:
+                        loss_scale_factor = 1 / self.gradient_accumulation
+
+                    entropy, log_prob = self._forward_micro_batch(
+                        model_inputs, temperature=temperature, calculate_entropy=calculate_entropy
+                    )
+
+                    if hasattr(self.config, "use_rollout_log_probs") and self.config.use_rollout_log_probs:
+                        old_log_prob = model_inputs["old_log_probs"]
+                    else:
+                        old_log_prob = log_prob.detach() if on_policy else model_inputs["old_log_probs"]
+
+                    loss_mode = self.config.policy_loss.get("loss_mode", "vanilla")
+                    rollout_is_weights = model_inputs.get("rollout_is_weights", None)
+                    policy_loss_fn = get_policy_loss_fn(loss_mode)
+                    pg_loss, pg_metrics = policy_loss_fn(
+                        old_log_prob=old_log_prob,
+                        log_prob=log_prob,
+                        advantages=advantages,
+                        response_mask=response_mask,
+                        loss_agg_mode=loss_agg_mode,
+                        config=self.config,
+                        rollout_is_weights=rollout_is_weights,
+                    )
+                    micro_batch_metrics.update(pg_metrics)
+
+                    rollout_log_prob = model_inputs.get("rollout_log_probs", None)
+                    if loss_mode != "bypass_mode" and rollout_log_prob is not None:
+                        from verl.trainer.ppo.rollout_corr_helper import compute_rollout_corr_metrics_from_logprobs
+
+                        rollout_corr_metrics = compute_rollout_corr_metrics_from_logprobs(
+                            log_prob=log_prob,
+                            rollout_log_prob=rollout_log_prob,
+                            response_mask=response_mask,
+                        )
+                        micro_batch_metrics.update(rollout_corr_metrics)
+
+                    policy_loss = pg_loss
+                    if calculate_entropy and entropy is not None:
+                        entropy_agg = agg_loss(loss_mat=entropy, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+                        micro_batch_metrics["actor/entropy"] = entropy_agg.detach().item()
+                        if entropy_coeff != 0:
+                            policy_loss -= entropy_agg * entropy_coeff
+
+                    if self.config.use_kl_loss:
+                        ref_log_prob = model_inputs["ref_log_prob"]
+                        kld = kl_penalty(
+                            logprob=log_prob, ref_logprob=ref_log_prob, kl_penalty=self.config.kl_loss_type
+                        )
+                        kl_loss = agg_loss(loss_mat=kld, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+                        policy_loss = policy_loss + kl_loss * self.config.kl_loss_coef
+                        metrics["actor/kl_loss"] += kl_loss.detach().item() * loss_scale_factor
+                        micro_batch_metrics["actor/kl_coef"] = self.config.kl_loss_coef
+
+                    loss = policy_loss * loss_scale_factor
+                    if self.scaler is not None:
+                        self.scaler.scale(loss).backward()
+                    else:
+                        loss.backward()
+
+                    metrics["actor/pg_loss"] += pg_loss.detach().item() * loss_scale_factor
+                    append_to_dict(metrics, micro_batch_metrics)
+
+                grad_norm = self._optimizer_step()
+                append_to_dict(metrics, {"actor/grad_norm": grad_norm.detach().item()})
+
+        self.actor_optimizer.zero_grad()
+        return metrics

--- a/agent_r1/workers/critic/__init__.py
+++ b/agent_r1/workers/critic/__init__.py
@@ -1,0 +1,3 @@
+from .dp_critic import DataParallelPPOCritic
+
+__all__ = ["DataParallelPPOCritic"]

--- a/agent_r1/workers/critic/dp_critic.py
+++ b/agent_r1/workers/critic/dp_critic.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Agent-R1 local PPO critic overrides.
+"""
+
+import logging
+import os
+
+from agent_r1.trainer.ppo.core_algos import compute_value_loss
+from verl import DataProto
+from verl.utils.device import get_device_id
+from verl.utils.profiler import GPUMemoryLogger
+from verl.utils.py_functional import append_to_dict
+from verl.utils.seqlen_balancing import prepare_dynamic_batch
+from verl.utils.torch_functional import masked_mean
+from verl.workers.critic.dp_critic import DataParallelPPOCritic as VerlDataParallelPPOCritic
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class DataParallelPPOCritic(VerlDataParallelPPOCritic):
+    @GPUMemoryLogger(role="dp critic", logger=logger)
+    def update_critic(self, data: DataProto):
+        self.critic_module.train()
+        metrics = {
+            "critic/vf_loss": 0.0,
+        }
+
+        select_keys = ["input_ids", "responses", "response_mask", "attention_mask", "position_ids", "values", "returns"]
+        has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
+        non_tensor_select_keys = ["multi_modal_inputs"] if has_multi_modal_inputs else []
+
+        data = data.select(batch_keys=select_keys, non_tensor_batch_keys=non_tensor_select_keys)
+        mini_batches = data.split(self.config.ppo_mini_batch_size)
+
+        for _ in range(self.config.ppo_epochs):
+            for mini_batch in mini_batches:
+                if self.config.use_dynamic_bsz:
+                    max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
+                    micro_batches, _ = prepare_dynamic_batch(mini_batch, max_token_len=max_token_len)
+                else:
+                    micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)
+
+                micro_batches = [mb for mb in micro_batches if bool(mb.batch["response_mask"].any().item())]
+                if not micro_batches:
+                    append_to_dict(metrics, {"critic/grad_norm": 0.0})
+                    continue
+
+                if not self.config.use_dynamic_bsz:
+                    self.gradient_accumulation = len(micro_batches)
+
+                self.critic_optimizer.zero_grad()
+
+                for micro_batch in micro_batches:
+                    micro_batch = micro_batch.to(get_device_id())
+                    model_inputs = {**micro_batch.batch, **micro_batch.non_tensor_batch}
+                    response_mask = model_inputs["response_mask"]
+                    values = model_inputs["values"]
+                    returns = model_inputs["returns"]
+
+                    vpreds = self._forward_micro_batch(model_inputs)
+                    vf_loss, vf_clipfrac = compute_value_loss(
+                        vpreds=vpreds,
+                        values=values,
+                        returns=returns,
+                        response_mask=response_mask,
+                        cliprange_value=self.config.cliprange_value,
+                        loss_agg_mode=self.config.loss_agg_mode,
+                    )
+                    if self.config.use_dynamic_bsz:
+                        loss_scale_factor = response_mask.shape[0] / self.config.ppo_mini_batch_size
+                    else:
+                        loss_scale_factor = 1 / self.gradient_accumulation
+                    loss = vf_loss * loss_scale_factor
+                    loss.backward()
+
+                    append_to_dict(
+                        metrics,
+                        {
+                            "critic/vf_clipfrac": vf_clipfrac.detach().item(),
+                            "critic/vpred_mean": masked_mean(vpreds, response_mask).detach().item(),
+                        },
+                    )
+                    metrics["critic/vf_loss"] += vf_loss.detach().item() * loss_scale_factor
+
+                grad_norm = self._optimizer_step()
+                append_to_dict(metrics, {"critic/grad_norm": grad_norm.detach().item()})
+
+        self.critic_optimizer.zero_grad()
+        return metrics

--- a/agent_r1/workers/engine_workers.py
+++ b/agent_r1/workers/engine_workers.py
@@ -32,7 +32,6 @@ from verl.workers.engine import utils as engine_utils
 from verl.workers.engine_workers import ActorRolloutRefWorker as VerlActorRolloutRefWorker
 from verl.workers.engine_workers import TrainingWorker as VerlTrainingWorker
 
-
 _ORIGINAL_PREPARE_MICRO_BATCHES = engine_utils.prepare_micro_batches
 
 

--- a/agent_r1/workers/engine_workers.py
+++ b/agent_r1/workers/engine_workers.py
@@ -1,0 +1,120 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Thin new-engine worker wrappers that swap in Agent-R1 local losses.
+"""
+
+from functools import partial
+from itertools import chain
+
+import torch
+from codetiming import Timer
+from tensordict import NonTensorData, TensorDict
+
+from agent_r1.workers.utils.losses import ppo_loss
+from verl.single_controller.base.decorator import Dispatch, make_nd_compute_dataproto_dispatch_fn, register
+from verl.utils import tensordict_utils as tu
+from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.py_functional import append_to_dict
+from verl.workers.config import ActorConfig
+from verl.workers.engine_workers import ActorRolloutRefWorker as VerlActorRolloutRefWorker
+from verl.workers.engine_workers import TrainingWorker as VerlTrainingWorker
+
+
+class TrainingWorker(VerlTrainingWorker):
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="train"), blocking=False)
+    def train_mini_batch(self, data: TensorDict) -> TensorDict:
+        if "mini_batch_id" not in data.keys():
+            return super().train_mini_batch(data)
+
+        disable_auto_offload = tu.pop(data, key="disable_auto_offload", default=False)
+        mini_batch_size = tu.pop(data, key="mini_batch_size", default=None)
+        num_mini_batch = tu.pop(data, key="num_mini_batch", default=None)
+        epochs = tu.pop(data, key="epochs", default=1)
+        seed = tu.pop(data, key="seed", default=42)
+        dataloader_kwargs = tu.pop(data, key="dataloader_kwargs", default={})
+        mini_batch_ids = data.pop("mini_batch_id").to(dtype=torch.long)
+        mini_batch_global_sizes = data.pop("mini_batch_global_size").to(dtype=torch.long)
+        mini_batch_global_token_nums = data.pop("mini_batch_global_token_num").to(dtype=torch.long)
+
+        assert mini_batch_size is not None or num_mini_batch is not None
+        assert dataloader_kwargs.keys() <= {"shuffle"}, f"Unsupported dataloader_kwargs: {dataloader_kwargs.keys()}"
+
+        unique_mini_batch_ids = torch.unique(mini_batch_ids, sorted=True).cpu()
+        total_num_iterations = len(unique_mini_batch_ids) * epochs
+        shuffle = dataloader_kwargs.get("shuffle", False)
+
+        with (
+            self.engine.train_mode(disable_auto_offload=disable_auto_offload),
+            Timer(name="train_batch", logger=None),
+        ):
+            output_lst = []
+            iteration_idx = 0
+            for epoch in range(epochs):
+                epoch_mini_batch_ids = unique_mini_batch_ids
+                if shuffle:
+                    generator = torch.Generator()
+                    generator.manual_seed(seed + epoch)
+                    permutation = torch.randperm(len(epoch_mini_batch_ids), generator=generator)
+                    epoch_mini_batch_ids = epoch_mini_batch_ids[permutation]
+
+                for mini_batch_id in epoch_mini_batch_ids:
+                    indices = torch.nonzero(mini_batch_ids.cpu() == mini_batch_id, as_tuple=False).flatten()
+                    mini_batch_td = tu.index_select_tensor_dict(data, indices)
+
+                    global_token_num = mini_batch_global_token_nums[indices[0]].tolist()
+                    global_batch_size = int(mini_batch_global_sizes[indices[0]].item())
+
+                    tu.assign_non_tensor(
+                        mini_batch_td,
+                        global_token_num=NonTensorData(global_token_num),
+                        global_batch_size=global_batch_size,
+                        update_lr_scheduler=iteration_idx == total_num_iterations - 1,
+                        disable_auto_offload=True,
+                    )
+                    output_lst.append(self.train_batch(mini_batch_td))
+                    iteration_idx += 1
+
+            if self.engine.is_mp_src_rank_with_outputs():
+                actor_output = [tu.get(output, "metrics") for output in output_lst]
+                metrics = {}
+                for output in actor_output:
+                    for key, val in output.items():
+                        if isinstance(val, list):
+                            output[key] = list(chain.from_iterable(val))
+                    append_to_dict(metrics, output)
+
+                output = tu.get_tensordict(tensor_dict={}, non_tensor_dict={"metrics": metrics}).cpu()
+            else:
+                output = None
+        return output
+
+
+class ActorRolloutRefWorker(VerlActorRolloutRefWorker):
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+        import verl.workers.engine_workers as upstream_engine_workers
+
+        original_training_worker = upstream_engine_workers.TrainingWorker
+        upstream_engine_workers.TrainingWorker = TrainingWorker
+        try:
+            super().init_model()
+        finally:
+            upstream_engine_workers.TrainingWorker = original_training_worker
+
+        if "actor" in self.role:
+            actor_config: ActorConfig = omega_conf_to_dataclass(self.config.actor)
+            actor_config.model_config = self.config.model
+            self.loss_fn = partial(ppo_loss, config=actor_config)
+            self.actor.set_loss_fn(self.loss_fn)

--- a/agent_r1/workers/engine_workers.py
+++ b/agent_r1/workers/engine_workers.py
@@ -28,8 +28,78 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.py_functional import append_to_dict
 from verl.workers.config import ActorConfig
+from verl.workers.engine import utils as engine_utils
 from verl.workers.engine_workers import ActorRolloutRefWorker as VerlActorRolloutRefWorker
 from verl.workers.engine_workers import TrainingWorker as VerlTrainingWorker
+
+
+_ORIGINAL_PREPARE_MICRO_BATCHES = engine_utils.prepare_micro_batches
+
+
+def _prepare_micro_batches(
+    data: TensorDict,
+    dp_group=None,
+    num_batches_divided_by=None,
+    same_micro_num_in_dp=True,
+    min_num_micro_batch=None,
+    use_dynamic_bsz_balance=True,
+):
+    # Keep verl's dynamic path unchanged. For static micro-batching, allow a short
+    # tail batch and sync the micro-batch count across DP ranks before slicing.
+    use_dynamic_bsz = tu.get_non_tensor_data(data=data, key="use_dynamic_bsz", default=True)
+    if use_dynamic_bsz:
+        return _ORIGINAL_PREPARE_MICRO_BATCHES(
+            data=data,
+            dp_group=dp_group,
+            num_batches_divided_by=num_batches_divided_by,
+            same_micro_num_in_dp=same_micro_num_in_dp,
+            min_num_micro_batch=min_num_micro_batch,
+            use_dynamic_bsz_balance=use_dynamic_bsz_balance,
+        )
+
+    micro_batch_size_per_gpu = data["micro_batch_size_per_gpu"]
+    assert micro_batch_size_per_gpu > 0, f"micro_batch_size_per_gpu must be positive, got {micro_batch_size_per_gpu}"
+    num_micro_batches = (len(data) + micro_batch_size_per_gpu - 1) // micro_batch_size_per_gpu
+
+    if torch.distributed.is_initialized() and same_micro_num_in_dp:
+        num_micro_batches_tensor = torch.tensor([num_micro_batches], dtype=torch.long, device=data["input_ids"].device)
+        torch.distributed.all_reduce(num_micro_batches_tensor, op=torch.distributed.ReduceOp.MAX, group=dp_group)
+        num_micro_batches = int(num_micro_batches_tensor.cpu().item())
+
+    if num_batches_divided_by is not None:
+        num_micro_batches = ((num_micro_batches + num_batches_divided_by - 1) // num_batches_divided_by) * (
+            num_batches_divided_by
+        )
+
+    if num_micro_batches > len(data):
+        raise ValueError(
+            f"num_micro_batches ({num_micro_batches}) must be <= local batch size ({len(data)}) "
+            "when use_dynamic_bsz is disabled"
+        )
+
+    micro_batches = [
+        tu.index_select_tensor_dict(
+            data,
+            list(
+                range(
+                    micro_batch_id * len(data) // num_micro_batches,
+                    (micro_batch_id + 1) * len(data) // num_micro_batches,
+                )
+            ),
+        )
+        for micro_batch_id in range(num_micro_batches)
+    ]
+    return micro_batches, None
+
+
+def _install_prepare_micro_batches_patch() -> None:
+    from verl.workers.engine.fsdp import transformer_impl as fsdp_transformer_impl
+
+    engine_utils.prepare_micro_batches = _prepare_micro_batches
+    fsdp_transformer_impl.prepare_micro_batches = _prepare_micro_batches
+
+
+_install_prepare_micro_batches_patch()
 
 
 class TrainingWorker(VerlTrainingWorker):
@@ -73,7 +143,8 @@ class TrainingWorker(VerlTrainingWorker):
                     indices = torch.nonzero(mini_batch_ids.cpu() == mini_batch_id, as_tuple=False).flatten()
                     mini_batch_td = tu.index_select_tensor_dict(data, indices)
 
-                    global_token_num = mini_batch_global_token_nums[indices[0]].tolist()
+                    global_token_num = mini_batch_global_token_nums[indices[0]]
+                    global_token_num = global_token_num[global_token_num > 0].tolist()
                     global_batch_size = int(mini_batch_global_sizes[indices[0]].item())
 
                     tu.assign_non_tensor(

--- a/agent_r1/workers/fsdp_workers.py
+++ b/agent_r1/workers/fsdp_workers.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Thin FSDP worker wrappers that swap in Agent-R1 local actor/critic implementations.
+"""
+
+from verl.single_controller.base.decorator import Dispatch, register
+from verl.utils.config import omega_conf_to_dataclass
+from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker as VerlAsyncActorRolloutRefWorker
+from verl.workers.fsdp_workers import CriticWorker as VerlCriticWorker
+
+
+class AsyncActorRolloutRefWorker(VerlAsyncActorRolloutRefWorker):
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+        super().init_model()
+
+        from agent_r1.workers.actor import DataParallelPPOActor
+
+        if self._is_actor:
+            actor_cfg = omega_conf_to_dataclass(self.config.actor)
+            self.actor = DataParallelPPOActor(
+                config=actor_cfg, actor_module=self.actor_module_fsdp, actor_optimizer=self.actor_optimizer
+            )
+
+        if self._is_ref:
+            self.ref_policy = DataParallelPPOActor(config=self.config.ref, actor_module=self.ref_module_fsdp)
+
+
+class CriticWorker(VerlCriticWorker):
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+        super().init_model()
+
+        from agent_r1.workers.critic import DataParallelPPOCritic
+
+        self.critic = DataParallelPPOCritic(
+            config=self.config, critic_module=self.critic_module, critic_optimizer=self.critic_optimizer
+        )

--- a/agent_r1/workers/utils/__init__.py
+++ b/agent_r1/workers/utils/__init__.py
@@ -1,0 +1,3 @@
+from .losses import ppo_loss, sft_loss, value_loss
+
+__all__ = ["ppo_loss", "sft_loss", "value_loss"]

--- a/agent_r1/workers/utils/losses.py
+++ b/agent_r1/workers/utils/losses.py
@@ -1,0 +1,148 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn.functional as F
+from tensordict import TensorDict
+
+from agent_r1.trainer.ppo.core_algos import agg_loss, compute_value_loss, get_policy_loss_fn
+from verl.trainer.ppo.core_algos import kl_penalty
+from verl.utils import tensordict_utils as tu
+from verl.utils.dataset.dataset_utils import DatasetPadMode
+from verl.utils.torch_functional import masked_mean, masked_sum
+from verl.workers.config import ActorConfig, CriticConfig
+
+
+def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
+    pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
+    dp_size = data["dp_size"]
+    batch_num_tokens = data["batch_num_tokens"]
+
+    log_prob = model_output["log_probs"]
+
+    if pad_mode == DatasetPadMode.NO_PADDING:
+        loss_mask = data["loss_mask"]
+        log_prob_flatten = log_prob.values()
+        loss_mask_flatten = loss_mask.values()
+        loss_mask_flatten = torch.roll(loss_mask_flatten, shifts=-1, dims=0)
+        loss = -masked_sum(log_prob_flatten, loss_mask_flatten) / batch_num_tokens * dp_size
+    else:
+        response_mask = data["response_mask"].to(bool)
+        loss = -masked_sum(log_prob, response_mask) / batch_num_tokens * dp_size
+
+    return loss, {}
+
+
+def _slice_response_from_unpad_output(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor:
+    values = tensor.values() if tensor.is_nested else tensor
+    prompt_ids = data["prompts"]
+    response_ids = data["responses"]
+    attention_mask = data["attention_mask"]
+
+    if prompt_ids.is_nested:
+        prompt_lens = prompt_ids.offsets().diff()
+        response_lens = response_ids.offsets().diff()
+        max_response_len = response_ids.offsets().max().item()
+    else:
+        assert not attention_mask.is_nested
+        prompt_lens = attention_mask[:, : prompt_ids.shape[1]].sum(dim=1)
+        response_lens = attention_mask[:, prompt_ids.shape[1] :].sum(dim=1)
+        max_response_len = response_ids.shape[1]
+
+    sequence_lens = prompt_lens + response_lens
+    sequence_offsets = sequence_lens.cumsum(dim=0)
+    assert sequence_offsets[-1].item() == values.shape[0]
+
+    response_list = []
+    for resp_len, seq_offset in zip(response_lens, sequence_offsets, strict=True):
+        pad_size = max_response_len - resp_len
+        response_list.append(F.pad(values[seq_offset - resp_len - 1 : seq_offset - 1], (0, pad_size)))
+
+    return torch.stack(response_list, dim=0)
+
+
+def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
+    log_prob = _slice_response_from_unpad_output(model_output["log_probs"], data)
+    entropy = model_output.get("entropy", None)
+    if entropy is not None:
+        entropy = _slice_response_from_unpad_output(entropy, data)
+
+    config.global_batch_info["dp_size"] = data["dp_size"]
+    config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
+    config.global_batch_info["global_batch_size"] = data["global_batch_size"]
+    config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
+
+    metrics = {}
+    response_mask = data["response_mask"].to(bool)
+    old_log_prob = data["old_log_probs"]
+    advantages = data["advantages"]
+    rollout_is_weights = data.get("rollout_is_weights", None)
+    loss_agg_mode = config.loss_agg_mode
+    loss_mode = config.policy_loss.get("loss_mode", "vanilla")
+
+    policy_loss_fn = get_policy_loss_fn(loss_mode)
+    pg_loss, pg_metrics = policy_loss_fn(
+        old_log_prob=old_log_prob,
+        log_prob=log_prob,
+        advantages=advantages,
+        response_mask=response_mask,
+        loss_agg_mode=loss_agg_mode,
+        config=config,
+        rollout_is_weights=rollout_is_weights,
+    )
+
+    metrics.update(pg_metrics)
+    metrics["actor/pg_loss"] = pg_loss.detach().item()
+    policy_loss = pg_loss
+
+    if entropy is not None:
+        entropy_loss = agg_loss(
+            loss_mat=entropy, loss_mask=response_mask, loss_agg_mode=loss_agg_mode, **config.global_batch_info
+        )
+        policy_loss -= config.entropy_coeff * entropy_loss
+
+    if config.use_kl_loss:
+        ref_log_prob = data["ref_log_prob"]
+        kld = kl_penalty(logprob=log_prob, ref_logprob=ref_log_prob, kl_penalty=config.kl_loss_type)
+        kl_loss = agg_loss(
+            loss_mat=kld, loss_mask=response_mask, loss_agg_mode=config.loss_agg_mode, **config.global_batch_info
+        )
+        policy_loss += kl_loss * config.kl_loss_coef
+        metrics["kl_loss"] = kl_loss.detach().item()
+        metrics["kl_coef"] = config.kl_loss_coef
+
+    return policy_loss, metrics
+
+
+def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=None):
+    vpreds = _slice_response_from_unpad_output(model_output["values"], data)
+    values = data["values"]
+    returns = data["returns"]
+    response_mask = data["response_mask"].to(bool)
+
+    vf_loss, vf_clipfrac = compute_value_loss(
+        vpreds=vpreds,
+        values=values,
+        returns=returns,
+        response_mask=response_mask,
+        cliprange_value=config.cliprange_value,
+        loss_agg_mode=config.loss_agg_mode,
+    )
+
+    metrics = {
+        "critic/vf_loss": vf_loss.detach().item(),
+        "critic/vf_clipfrac": vf_clipfrac.detach().item(),
+        "critic/vpred_mean": masked_mean(vpreds, response_mask).detach().item(),
+    }
+    return vf_loss, metrics


### PR DESCRIPTION
## Summary

Fix gradient bias caused by padded samples introduced for verl DP dispatch.

verl requires `DataProto` batches to be evenly divisible by the target DP dispatch size before splitting them across DP shards. To satisfy this constraint, the trainer pads post-rollout batches before actor / critic updates. These padded samples are dispatch artifacts and should not contribute to training.

Previously, padded samples could still affect loss normalization, mini-batch statistics, or critic value-loss masking in some FSDP / new-engine paths. When the number of real samples was not divisible by the DP dispatch size, different DP shards could observe different effective sample / token counts, causing biased actor or critic gradients.

This PR makes padded samples explicit via `sample_mask`, propagates global mini-batch sample / token statistics, and uses pad-aware Agent-R1-local loss aggregation so losses are normalized by real global training data rather than dispatch padding.

## Changes

- Introduce tensor-based `sample_mask` to explicitly mark samples added only for verl DP dispatch padding.
- Zero out `response_mask` for padded samples so dispatch padding cannot contribute to actor or critic loss.
- Update valid-data filtering to use `sample_mask` instead of the previous non-tensor `is_pad` marker.
- Compute the padding divisor from the actual training dispatch DP sizes instead of treating padding as a generic worker-world-size requirement.
- Add global mini-batch metadata:
  - `mini_batch_id`
  - `mini_batch_global_size`
  - `mini_batch_global_token_num`
- Use these global statistics in pad-aware loss aggregation so loss denominators are based on real samples / tokens, not padded local shards.
- Add zero-denominator handling for empty or fully padded micro-batches.
- Patch actor / critic update paths to skip empty response micro-batches.
- Ensure critic value masks exclude padded samples during critic updates.
- Add Agent-R1-local policy / value loss implementations and worker wrappers to apply the corrected aggregation consistently across legacy FSDP and new-engine paths.
- Patch new-engine static micro-batch splitting to handle uneven local batches while keeping DP ranks synchronized on micro-batch count.

## Notes
- This PR keeps verl's current DP dispatch / `DataProto` chunking behavior and makes the training path pad-aware. As a follow-up, we can consider improving verl's dispatch logic to support uneven DP partitions directly, which should remove the need to pad `DataProto` batches purely for dispatch.
- This PR keeps the value loss aggregation aligned with upstream verl. A follow-up PR will separately audit whether global normalization kwargs should be propagated beyond the policy loss path in the new engine, including `compute_value_loss` and related metric-only aggregations where applicable.
- A separate verl new-engine `compute_values` collection issue was observed for nested value outputs. It appears unrelated to this padding-gradient fix and can be addressed later with a dedicated verl patch.
