### PR TITLE
Fix agent flow registration dropping YAML config fields

### DIFF
--- a/agent_r1/agent_flow/agent_flow.py
+++ b/agent_r1/agent_flow/agent_flow.py
@@ -456,7 +456,10 @@ def register(agent_name: str):
 
     def decorator(subclass: type[AgentFlowBase]) -> type[AgentFlowBase]:
         fqdn = f"{subclass.__module__}.{subclass.__qualname__}"
-        _agent_flow_registry[agent_name] = {"_target_": fqdn}
+        if agent_name in _agent_flow_registry:
+            _agent_flow_registry[agent_name]["_target_"] = fqdn
+        else:
+            _agent_flow_registry[agent_name] = {"_target_": fqdn}
         return subclass
 
     return decorator


### PR DESCRIPTION
## Summary

Fix a bug where Hydra target imports could cause agent flow registration to drop fields loaded from YAML config.

## Changes

* update `register()` to preserve existing registry entries and only refresh `_target_`
* keep first-time agent flow registration behavior unchanged
