### PR TITLE
Fix: add missing expanduser and makedirs in gsm8k preprocessing

### DIFF
--- a/examples/data_preprocess/gsm8k.py
+++ b/examples/data_preprocess/gsm8k.py
@@ -96,6 +96,9 @@ if __name__ == "__main__":
     else:
         local_save_dir = args.local_save_dir
 
+    local_save_dir = os.path.expanduser(local_save_dir)
+    os.makedirs(local_save_dir, exist_ok=True)
+
     train_dataset.to_parquet(os.path.join(local_save_dir, "train.parquet"))
     test_dataset.to_parquet(os.path.join(local_save_dir, "test.parquet"))
 


### PR DESCRIPTION
## Problem

The `gsm8k.py` preprocessing script uses `--local_save_dir=~/data/gsm8k` as default but never calls `os.path.expanduser()` or `os.makedirs()`, causing it to fail with default arguments.

The sister script `gsm8k_tool.py` already has both calls — this is an oversight.

## Fix

Added `os.path.expanduser(local_save_dir)` and `os.makedirs(local_save_dir, exist_ok=True)` before writing parquet files.

Fixes similar pattern to `gsm8k_tool.py`.