### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,4 +200,4 @@ If you find Agent-R1 useful in your research, please cite:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AgentR1/Agent-R1&type=Date)](https://www.star-history.com/#AgentR1/Agent-R1&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AgentR1/Agent-R1&type=Date)](https://star-history.dera.page/#AgentR1/Agent-R1&Date)


### PR DESCRIPTION
The star history chart in the README currently fails to render because the upstream service is broken due to GitHub stargazer API restrictions. This change switches it to a working alternative provider so the chart displays correctly again.